### PR TITLE
add bold, italic Lato to font import

### DIFF
--- a/urbn.scss
+++ b/urbn.scss
@@ -2,7 +2,7 @@
 $theme: "urbn" !default;
 
 // importing fonts
-@import url('https://fonts.googleapis.com/css2?family=Inconsolata&family=Lato&family=Yanone+Kaffeesatz&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inconsolata&family=Lato:bold,italic,bolditalic&family=Yanone+Kaffeesatz&display=swap');
 
 //
 // Color system


### PR DESCRIPTION
Realized that bold text didn't render in Chrome because apparently (and annoyingly) you need to import the bold/italic fonts explicitly, from the [docs](https://developers.google.com/fonts/docs/getting_started#specifying_font_families_and_styles_in_a_stylesheet_url): 

 > The Google Fonts API provides the regular version of the requested fonts by default. To request other styles or weights, append a colon (:) to the name of the font, followed by a list of styles or weights separated by commas (,).